### PR TITLE
zfill 

### DIFF
--- a/string.gs
+++ b/string.gs
@@ -313,3 +313,12 @@ func repeatstr(text, count) {
         }                                                                              \
         i++;                                                                           \
     }
+
+# Fill a string with zeroes to the left so that is the specified length.
+func zfill(s, zeroes) {
+    local ret = $s;
+    repeat $zeroes - length $s {
+        ret = 0 & ret;
+    }
+    return ret;
+}


### PR DESCRIPTION
zfill is a simple string manipulator from python that adds zeroes to the front of a string until a specified length. it is especially convenient in some situations like with HEX color codes which require 2 digits